### PR TITLE
defect #550005 : TFS pipeline run results are not sent back to Octane

### DIFF
--- a/OctaneManager/Configuration/ConfigurationManager.cs
+++ b/OctaneManager/Configuration/ConfigurationManager.cs
@@ -36,10 +36,14 @@ namespace MicroFocus.Adm.Octane.CiPlugins.Tfs.Core.Configuration
 			WatchForConfigFileChanges();
 		}
 
-		public static ConnectionDetails Read()
+		public static ConnectionDetails Read(bool printLogs)
 		{
 			var fullConfigFilePath = GetConfigFilePath();
-			Log.Debug($"Loading configuration from {fullConfigFilePath}");
+			if (printLogs)
+			{
+				Log.Debug($"Loading configuration from {fullConfigFilePath}");
+			}
+			
 			if (!File.Exists(fullConfigFilePath))
 			{
 				throw new FileNotFoundException($"Configuration file {fullConfigFilePath} was not found!");
@@ -54,9 +58,12 @@ namespace MicroFocus.Adm.Octane.CiPlugins.Tfs.Core.Configuration
 				}
 			}
 
-			ConnectionDetails resForLog = JsonHelper.DeserializeObject<ConnectionDetails>(configJson);
-			resForLog.RemoveSensitiveInfo();
-			Log.Info($"Loaded configuration : {JsonHelper.SerializeObject(resForLog, true)}");
+			if (printLogs)
+			{
+				ConnectionDetails resForLog = JsonHelper.DeserializeObject<ConnectionDetails>(configJson);
+				resForLog.RemoveSensitiveInfo();
+				Log.Info($"Loaded configuration : {JsonHelper.SerializeObject(resForLog, true)}");
+			}
 
 			ConnectionDetails res = JsonHelper.DeserializeObject<ConnectionDetails>(configJson);
 			return res;

--- a/OctaneManager/PluginManager.cs
+++ b/OctaneManager/PluginManager.cs
@@ -48,7 +48,7 @@ namespace MicroFocus.Ci.Tfs.Octane
 		{
 			try
 			{
-				ConnectionDetails tempConf = ConfigurationManager.Read();
+				ConnectionDetails tempConf = ConfigurationManager.Read(true);
 				ConnectionCreator.CheckMissingValues(tempConf);
 				_connectionDetails = tempConf;
 			}

--- a/OctaneManager/RestServer/RestBase.cs
+++ b/OctaneManager/RestServer/RestBase.cs
@@ -107,7 +107,7 @@ namespace MicroFocus.Adm.Octane.CiPlugins.Tfs.Core.RestServer
 				ConnectionDetails conf = null;
 				try
 				{
-					conf = ConfigurationManager.Read();
+					conf = ConfigurationManager.Read(false);
 				}
 				catch (FileNotFoundException)
 				{

--- a/OctaneManager/Tools/ConnectionCreator.cs
+++ b/OctaneManager/Tools/ConnectionCreator.cs
@@ -49,6 +49,10 @@ namespace MicroFocus.Adm.Octane.CiPlugins.Tfs.Core.Tools
 			{
 				throw new ArgumentException("InstanceId is missing");
 			}
+			if (connectionDetails.InstanceId.Length > 40)
+			{
+				throw new ArgumentException("InstanceId length must be less than or equal to 40 characters");
+			}
 		}
 
 		public static TfsApis CreateTfsConnection(ConnectionDetails connectionDetails)


### PR DESCRIPTION
The issue was : tfs instance id was too long (more than 40 characters).

Now,  there is clear log message if instance id is too long