### PR TITLE
Queue manager throw events if its not possible to handle them

### DIFF
--- a/OctaneManager/PluginManager.cs
+++ b/OctaneManager/PluginManager.cs
@@ -210,7 +210,7 @@ namespace MicroFocus.Ci.Tfs.Octane
 
 		public void RestartPlugin()
 		{
-			Log.Info($"Plugin restarted");
+			Log.Info($"Plugin is restarting");
 
 			StopAllThreads();
 			Task.Factory.StartNew(() =>


### PR DESCRIPTION
Queue manager throw events if its not possible to handle them (not related to losing connection to octane)
If connection to Octane is lost - queue manager is stopped until connection is restored and only after that trying to send event